### PR TITLE
Do not redirect on error

### DIFF
--- a/lib/util/response.js
+++ b/lib/util/response.js
@@ -29,18 +29,8 @@ module.exports.error = function(req, res, err, redirectUri) {
         emitter.caught_exception(req, err);
         req.oauth2.logger[err.logLevel]('Exception caught', err.stack);
     }
-        
-    if (redirectUri) {
-        var obj = {
-            error: err.code,
-            error_description: err.message
-        };
-        if (req.query.state) obj.state = req.query.state;
-        redirectUri += '?' + query.stringify(obj);
-        redirect(req, res, redirectUri);
-    }
-    else
-        data(req, res, err.status, {error: err.code, error_description: err.message});
+
+    data(req, res, err.status, {error: err.code, error_description: err.message});
 };
 
 module.exports.data = function(req, res, obj, redirectUri, anchor) {

--- a/test/authorizationCode.js
+++ b/test/authorizationCode.js
@@ -87,6 +87,23 @@ describe('Authorization Code Grant Type ',function() {
             })
     });
 
+    it('POST /authorize with invalid params expect to return 400 error', function(done) {
+        invalid_client_id = 123
+        request(app)
+            .post(authorizationUrl + '?' + query.stringify({
+                redirect_uri: data.clients[1].redirectUri,
+                client_id: invalid_client_id,
+                response_type: 'code'
+            }))
+            .send({ decision: 1 })
+            .set('Cookie', cookie)
+            .expect(400, function(err, res) {
+                if (err) return done(err);
+                done();
+            })
+    });
+
+
     it('POST /token with grant_type="authorization_code" expect token', function(done) {
         request(app)
             .post('/token')

--- a/test/authorizationCode.js
+++ b/test/authorizationCode.js
@@ -53,6 +53,18 @@ describe('Authorization Code Grant Type ',function() {
             });
     });
 
+    it('GET /authorize with invalid params expect error', function(done) {
+        invalid_client_id = 123
+
+        request(app)
+            .get(authorizationUrl + '?' + query.stringify({client_id: invalid_client_id}))
+            .set('Cookie', cookie)
+            .expect(400, function(err, res) {
+                if (err) return done(err);
+                done();
+            });
+    });
+
     it('POST /authorize with response_type="code" and decision="1" expect code redirect', function(done) {
         request(app)
             .post(authorizationUrl)

--- a/test/authorizationCode.js
+++ b/test/authorizationCode.js
@@ -57,7 +57,11 @@ describe('Authorization Code Grant Type ',function() {
         invalid_client_id = 123
 
         request(app)
-            .get(authorizationUrl + '?' + query.stringify({client_id: invalid_client_id}))
+            .get(authorizationUrl + '?' + query.stringify({
+                redirect_uri: data.clients[1].redirectUri,
+                client_id: invalid_client_id,
+                response_type: 'code'
+            }))
             .set('Cookie', cookie)
             .expect(400, function(err, res) {
                 if (err) return done(err);


### PR DESCRIPTION
Currently we redirect when there is an error. Instead lets just post the error response back to the user.