### PR TITLE
Fix open redirect issue, take 2

### DIFF
--- a/lib/util/response.js
+++ b/lib/util/response.js
@@ -26,17 +26,7 @@ module.exports.error = function(req, res, err, redirectUri) {
     else
         req.oauth2.logger[err.logLevel]('Exception caught', err.stack);
 
-    if (redirectUri) {
-        var obj = {
-            error: err.code,
-            error_description: err.message
-        };
-        if (req.query.state) obj.state = req.query.state;
-        redirectUri += '?' + query.stringify(obj);
-        redirect(req, res, redirectUri);
-    }
-    else
-        data(req, res, err.status, {error: err.code, error_description: err.message});
+    data(req, res, err.status, {error: err.code, error_description: err.message});
 };
 
 module.exports.data = function(req, res, obj, redirectUri, anchor) {

--- a/test/authorizationCode.js
+++ b/test/authorizationCode.js
@@ -53,6 +53,22 @@ describe('Authorization Code Grant Type ',function() {
             });
     });
 
+    it('GET /authorize with invalid params expect error', function(done) {
+        invalid_client_id = 123
+
+        request(app)
+            .get(authorizationUrl + '?' + query.stringify({
+                redirect_uri: data.clients[1].redirectUri,
+                client_id: invalid_client_id,
+                response_type: 'code'
+            }))
+            .set('Cookie', cookie)
+            .expect(400, function(err, res) {
+                if (err) return done(err);
+                done();
+            });
+    });
+
     it('POST /authorize with response_type="code" and decision="1" expect code redirect', function(done) {
         request(app)
             .post(authorizationUrl)
@@ -70,6 +86,23 @@ describe('Authorization Code Grant Type ',function() {
                 done();
             })
     });
+
+    it('POST /authorize with invalid params expect to return 400 error', function(done) {
+        invalid_client_id = 123
+        request(app)
+            .post(authorizationUrl + '?' + query.stringify({
+                redirect_uri: data.clients[1].redirectUri,
+                client_id: invalid_client_id,
+                response_type: 'code'
+            }))
+            .send({ decision: 1 })
+            .set('Cookie', cookie)
+            .expect(400, function(err, res) {
+                if (err) return done(err);
+                done();
+            })
+    });
+
 
     it('POST /token with grant_type="authorization_code" expect token', function(done) {
         request(app)


### PR DESCRIPTION
Trello: https://trello.com/c/DyWJGFbv/1292-fix-open-redirect-in-api-gateway-oauth

This is in fact a cherry-pick + squash of the commits in #3, rebased off commit 3de001259074a31c6830215506c0b7d86592cd02 which we've been [using in prod for the API Gateway](https://github.com/envato/api-gateway/blob/39a88f5dda2f2cd87345bb94f8610712c2a10ba5/package.json#L50)

Putting that fix on a more recent version, as attempted in #3, has [proved unreliable](https://github.com/envato/api-gateway/pull/219#issuecomment-356432244), causing errors like `TypeError: req.oauth2.model.accessToken.create isnot a
function`, presumably because our app just can't handle the newer versions, not because of anything in this change.

This is now based off 3de001259074a31c6830215506c0b7d86592cd02, from which I've checked out `envato-api-gateway`, which I plan to use as the effective prod branch for inclusion in envato/api-gateway, as the master branch here seems to be too recent for us (hopefully we'll get to catching up on that at some point). It works fine in dev.

cc @joneslee85 @envato/customer-uptime @yoshdog